### PR TITLE
Escape wildcard and descend into directories

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -54,7 +54,10 @@ function run() {
 
     // Replace class/package names in source code
     recursiveDir(JAVA_SRC_PATH, [function(file, stats){
-        return !file.match(".java");
+        if(stats.isDirectory()){
+            return false;
+        }
+        return !file.match("\\.java");
     }], attempt(function(err, files){
         if(err) throw err;
 


### PR DESCRIPTION
Current functionality is the adapter will modify any file it finds, which isn't the intended behavior.
The match method used in the recursive-readdir ignore function matches a regex, meaning the dot in ".java" is interpreted as a wildcard. Since JAVA_SRC_PATH has '/java' in it, there is always a match and nothing is ever ignored. 

Escaping the wildcard correctly checks for ".java" in the path.
A side effect of this change is recursive-readdir would ignore directories and not recurse into them. In the ignore function if the path is a directory, don't ignore it. 