### PR TITLE
docs: adds repository and bugs field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Cordova/Phonegap plugin to migrate any code which references the legacy Android Support Library to the new AndroidX mappings in a Cordova Android platform project.",
   "author": "Dave Alden",
   "license": "MIT",
+  "repository": "dpa99c/cordova-plugin-androidx-adapter",
+  "bugs": {
+    "url": "https://github.com/dpa99c/cordova-plugin-androidx-adapter/issues"
+  },
   "dependencies": {
     "q": "^1.4.1",
     "recursive-readdir": "^2.2.2",


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [ ] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
Currently the package misses the repository and bugs fields. While they are optional, it's nice to have them because the are used for `npm bugs`, `npm docs` commands and linked on the npmjs.com page (currently missing on https://www.npmjs.com/package/cordova-plugin-androidx-adapter)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information