### PR TITLE
feat: replaces perf function with Node.js builtin

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -7,7 +7,7 @@ var PROJECT_PROPERTIES_PATH = "./platforms/android/project.properties";
 var MANIFEST_PATH = "./platforms/android/app/src/main/AndroidManifest.xml";
 var TARGET_FILE_REGEX = /(\.java|\.xml)/;
 
-var deferral, fs, path, now, recursiveDir;
+var deferral, fs, path, perf_hooks, recursiveDir;
 
 function log(message) {
     console.log(PLUGIN_NAME + ": " + message);
@@ -23,12 +23,12 @@ function run() {
         fs = require('fs');
         path = require('path');
         recursiveDir = require("recursive-readdir");
-        now = require("performance-now")
+        perf_hooks = require('perf_hooks');
     } catch (e) {
         throw("Failed to load dependencies: " + e.toString());
     }
 
-    var startTime = now();
+    var startTime = perf_hooks.performance.now();
 
     var artifactMappings = JSON.parse(fs.readFileSync(path.join(__dirname, '.', ARTIFACT_MAPPINGS_FILE)).toString()),
         buildGradle = fs.readFileSync(BUILD_GRADLE_PATH).toString(),
@@ -36,7 +36,7 @@ function run() {
         androidManifest = fs.readFileSync(MANIFEST_PATH).toString();
 
     // Replace artifacts in build.gradle, project.properties & AndroidManifest.xml
-    for(var oldArtifactName in artifactMappings){
+    for (var oldArtifactName in artifactMappings) {
         var newArtifactName = artifactMappings[oldArtifactName],
             artifactRegExpStr = sanitiseForRegExp(oldArtifactName) + ':[0-9.+]+';
         buildGradle = buildGradle.replace(new RegExp(artifactRegExpStr, 'gm'), newArtifactName);
@@ -69,7 +69,7 @@ function run() {
             }
             fs.writeFileSync(filePath, fileContents, 'utf8');
         }
-        log("Processed " + files.length + " source files in " + parseInt(now() - startTime) + "ms");
+        log("Processed " + files.length + " source files in " + parseInt(perf_hooks.performance.now() - startTime) + "ms");
         deferral.resolve();
     }));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "cordova-plugin-androidx-adapter",
+  "version": "1.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
     "url": "https://github.com/dpa99c/cordova-plugin-androidx-adapter/issues"
   },
   "dependencies": {
-    "q": "^1.4.1",
-    "recursive-readdir": "^2.2.2",
-    "performance-now": "^2.1.0"
+    "q": "^1.5.1",
+    "recursive-readdir": "^2.2.2"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
## PR Type

This replaces the performance.now() function which is builtin since Node.js v8.5, updates q and adds a package-lock file

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

It kinda does, but Node.js v8.5.0 was released 2017-09-12 it shouldn't be breaking.

## What testing has been done on the changes in the PR?

Code still runs.

## What testing has been done on existing functionality?

## Other information